### PR TITLE
Create a namespace for a generated interface based on the assembly name

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -120,7 +120,7 @@ class Build : NukeBuild
         {
             var projectFiles = new[]
             {
-                RootDirectory / "tests/AutoDependencies.NugetIntegrationTests/AutoDepencencies.NugetIntegrationTests.csproj"
+                RootDirectory / "tests/AutoDependencies.NugetIntegrationTests/AutoDependencies.NugetIntegrationTests.csproj"
             };
 
             if (!string.IsNullOrEmpty(PackagesDirectory))

--- a/samples/AutoDependencies.Services/FirstService.cs
+++ b/samples/AutoDependencies.Services/FirstService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using AutoDependencies.Services.Interfaces.Generated;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AutoDependencies.Services;

--- a/samples/AutoDependencies.Services/Program.cs
+++ b/samples/AutoDependencies.Services/Program.cs
@@ -1,4 +1,4 @@
-﻿using AutoDependencies.Interfaces.Generated;
+﻿using AutoDependencies.Services.Interfaces.Generated;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AutoDependencies.Services;

--- a/src/AutoDependencies.Generator/Collectors/ConstructorMembersInfoCollector.cs
+++ b/src/AutoDependencies.Generator/Collectors/ConstructorMembersInfoCollector.cs
@@ -14,6 +14,7 @@ internal static class ConstructorMembersInfoCollector
             .OfType<MemberDeclarationSyntax>()
             .Where(memberDeclarationSyntax => CanBeConstructorMember(memberDeclarationSyntax, semanticModel))
             .Select(x => CreateConstructorMemberInfo(x, semanticModel))
+            .Where(x => x != null)
             .ToArray();
         
         return memberDeclarations;
@@ -59,8 +60,13 @@ internal static class ConstructorMembersInfoCollector
                 propertyDeclarationSyntax.Identifier,
                 propertyDeclarationSyntax.Type),
 
-            _ => throw new ArgumentOutOfRangeException(nameof(declarationSyntax), declarationSyntax, null)
+            _ => (default, default)
         };
+
+        if (identifier == default || type == default)
+        {
+            return null!;
+        }
 
         return new ConstructorMemberInfo(Name: identifier.Text, Type: type.ToFullNameTypeSyntax(semanticModel));
     }

--- a/src/AutoDependencies.Generator/Collectors/InterfaceMembersInfoCollector.cs
+++ b/src/AutoDependencies.Generator/Collectors/InterfaceMembersInfoCollector.cs
@@ -20,7 +20,9 @@ internal static class InterfaceMembersInfoCollector
                 ReturnType: x.ReturnType.ToFullNameTypeSyntax(semanticModel)))
             .ToArray();
 
-        return new(PredefinedNamespaces.GeneratedInterfacesNamespace, members);
+        var namespaceName = $"{semanticModel.Compilation.AssemblyName ?? "AutoDependencies"}.Interfaces.Generated";
+
+        return new(namespaceName, members);
     }
 
     private static bool CanBeInterfaceMember(MethodDeclarationSyntax syntax) =>

--- a/src/AutoDependencies.Generator/Constants/GeneratorConstants.cs
+++ b/src/AutoDependencies.Generator/Constants/GeneratorConstants.cs
@@ -11,7 +11,6 @@ public class GeneratorConstants
     public class PredefinedNamespaces
     {
         public const string AttributesNamespace = "AutoDependencies.Attributes";
-        public const string GeneratedInterfacesNamespace = "AutoDependencies.Interfaces.Generated";
     }
 
     public const string GeneratedDocumentExtension = ".g.cs";

--- a/src/AutoDependencies.Generator/SyntaxFactories/ServiceSyntaxFactory.cs
+++ b/src/AutoDependencies.Generator/SyntaxFactories/ServiceSyntaxFactory.cs
@@ -38,7 +38,7 @@ public static class ServiceSyntaxFactory
             .WithUsings(UsingSyntaxFactory.CreateUsingDirectiveList(new[]
             {
                 GeneratorConstants.PredefinedNamespaces.AttributesNamespace,
-                GeneratorConstants.PredefinedNamespaces.GeneratedInterfacesNamespace
+                interfaceInfo.NamespaceName
             }));
 
         return root.NormalizeWhitespace();

--- a/tests/AutoDependencies.IntegrationTests/ServiceGenerationTests.cs
+++ b/tests/AutoDependencies.IntegrationTests/ServiceGenerationTests.cs
@@ -1,6 +1,6 @@
+using AutoDependencies.IntegrationTests.Interfaces.Generated;
 using AutoDependencies.IntegrationTests.TestData;
 using AutoDependencies.IntegrationTests.TestData.External;
-using AutoDependencies.Interfaces.Generated;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AutoDependencies.IntegrationTests;

--- a/tests/AutoDependencies.IntegrationTests/ServiceGenerationTests.cs
+++ b/tests/AutoDependencies.IntegrationTests/ServiceGenerationTests.cs
@@ -1,4 +1,8 @@
+#if NUGET_INTEGRATION_TESTS
+using AutoDependencies.NugetIntegrationTests.Interfaces.Generated;
+#else
 using AutoDependencies.IntegrationTests.Interfaces.Generated;
+#endif
 using AutoDependencies.IntegrationTests.TestData;
 using AutoDependencies.IntegrationTests.TestData.External;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/AutoDependencies.IntegrationTests/TestData/TestService.cs
+++ b/tests/AutoDependencies.IntegrationTests/TestData/TestService.cs
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using AutoDependencies.IntegrationTests.Interfaces.Generated;
 
 namespace AutoDependencies.IntegrationTests.TestData;
 

--- a/tests/AutoDependencies.IntegrationTests/TestData/TestService.cs
+++ b/tests/AutoDependencies.IntegrationTests/TestData/TestService.cs
@@ -1,5 +1,10 @@
 ﻿using AutoDependencies.Attributes;
+using AutoDependencies.IntegrationTests.TestData.External;
+#if NUGET_INTEGRATION_TESTS
+using AutoDependencies.NugetIntegrationTests.Interfaces.Generated;
+#else
 using AutoDependencies.IntegrationTests.Interfaces.Generated;
+#endif
 
 namespace AutoDependencies.IntegrationTests.TestData;
 

--- a/tests/AutoDependencies.NugetIntegrationTests/AutoDependencies.NugetIntegrationTests.csproj
+++ b/tests/AutoDependencies.NugetIntegrationTests/AutoDependencies.NugetIntegrationTests.csproj
@@ -5,6 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
+		<DefineConstants>$(DefineConstants);NUGET_INTEGRATION_TESTS</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/AutoDependencies.Tests/ServiceConstructorSnapshotTests.cs
+++ b/tests/AutoDependencies.Tests/ServiceConstructorSnapshotTests.cs
@@ -79,7 +79,7 @@ public class ServiceConstructorSnapshotTests : SnapshotTestsBase<ServiceGenerato
     [Fact]
     public Task InjectGeneratedServiceInterface_ResolvesGeneratedInterface()
     {
-        var usingDirectives = new[] { $"using {GeneratorConstants.PredefinedNamespaces.GeneratedInterfacesNamespace};" };
+        var usingDirectives = new[] { "using Tests.Interfaces.Generated;" };
         var members = "private readonly ISecondService _secondService;";
 
         var source = GetSource(members, usingDirectives);

--- a/tests/AutoDependencies.Tests/Snapshots/NullableContextSnapshotTests.PrivateReadonlyField_NullableContext_ShouldAddNullableDirectiveIfEnabled_nullableContextEnabled=Disable.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/NullableContextSnapshotTests.PrivateReadonlyField_NullableContext_ShouldAddNullableDirectiveIfEnabled_nullableContextEnabled=Disable.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/NullableContextSnapshotTests.PrivateReadonlyField_NullableContext_ShouldAddNullableDirectiveIfEnabled_nullableContextEnabled=Enable.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/NullableContextSnapshotTests.PrivateReadonlyField_NullableContext_ShouldAddNullableDirectiveIfEnabled_nullableContextEnabled=Enable.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 #nullable enable
 namespace AutoDependencies.Services
@@ -14,7 +14,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceAttributeSnapshotTests.PartialClassWithServiceAttribute_GeneratesPartialClassWithEmptyConstructorAndInterface.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceAttributeSnapshotTests.PartialClassWithServiceAttribute_GeneratesPartialClassWithEmptyConstructorAndInterface.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.InjectGeneratedServiceInterface_ResolvesGeneratedInterface.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.InjectGeneratedServiceInterface_ResolvesGeneratedInterface.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=IExternalServicenull.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=IExternalServicenull.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=List-IExternalService-null.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=List-IExternalService-null.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=List-IExternalServicenull-.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=List-IExternalServicenull-.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=List-IExternalServicenull-null.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=List-IExternalServicenull-null.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=Nullable-int-.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=Nullable-int-.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=Nullable-int[]-.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=Nullable-int[]-.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=int[]null.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=int[]null.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=intnull.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=intnull.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=intnull[].verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=intnull[].verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=intnull[]null.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyFieldNullableType_GeneratesConstructorAndAssignProperty_type=intnull[]null.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyField_GeneratesConstructorWithOneParameterAndAssignProperty.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PrivateReadonlyField_GeneratesConstructorWithOneParameterAndAssignProperty.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -13,7 +13,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PropertiesAndFieldsWithInjectAttribute_GeneratesConstructorAndAssignPropertiesAndFields.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PropertiesAndFieldsWithInjectAttribute_GeneratesConstructorAndAssignPropertiesAndFields.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -15,7 +15,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PropertiesAndFieldsWithoutInjectAttribute_GeneratesConstructorWithNoParameters.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceConstructorSnapshotTests.PropertiesAndFieldsWithoutInjectAttribute_GeneratesConstructorWithNoParameters.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=internal.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=internal.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=private.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=private.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=protected.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.InaccessibleMethod_Void_DoesNotGenerateInterfaceMember_modifier=protected.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethodWithExpressionBody_String_GeneratesInterfaceMember.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethodWithExpressionBody_String_GeneratesInterfaceMember.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethodWithExternalTypeParameter_Void_GeneratesInterfaceMemberWithParameters.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethodWithExternalTypeParameter_Void_GeneratesInterfaceMemberWithParameters.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethodWithPrimitiveTypeParameter_Void_GeneratesInterfaceMemberWithParameters.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethodWithPrimitiveTypeParameter_Void_GeneratesInterfaceMemberWithParameters.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethod_String_GeneratesInterfaceMember.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethod_String_GeneratesInterfaceMember.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService

--- a/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethod_Void_GeneratesInterfaceMember.verified.txt
+++ b/tests/AutoDependencies.Tests/Snapshots/ServiceInterfaceSnapshotTests.PublicMethod_Void_GeneratesInterfaceMember.verified.txt
@@ -1,5 +1,5 @@
 ﻿using AutoDependencies.Attributes;
-using AutoDependencies.Interfaces.Generated;
+using Tests.Interfaces.Generated;
 
 namespace AutoDependencies.Services
 {
@@ -12,7 +12,7 @@ namespace AutoDependencies.Services
     }
 }
 
-namespace AutoDependencies.Interfaces.Generated
+namespace Tests.Interfaces.Generated
 {
     [Generated]
     public interface ITestService


### PR DESCRIPTION
Add: create a namespace for a generated interface based on the assembly name

Fix: suppress throwing an exception when syntax can't be parsed
Fix: typo in NuGet integration tests